### PR TITLE
add a catch for mods that increase inventory size over 1000

### DIFF
--- a/scripts/liquidtanks.lua
+++ b/scripts/liquidtanks.lua
@@ -31,7 +31,7 @@ end
 function setAnimationState()
 	liquidContainerActive = true
 
-	local currentLiquidCount = 0
+	-- local currentLiquidCount = 0
 	local imageType = "liquidwater"
 	local imageFrame = 1
 
@@ -68,7 +68,11 @@ function setAnimationState()
 	if currentLiquid ~= "" then
 		local currentLiquidCount = world.containerAvailable(entity.id(), currentLiquid)
 		local maxStack = getItemConfig(currentLiquid).maxStack
-		local maxCount = world.getObjectParameter(entity.id(), "slotCount") * maxStack
+		local maxCount = world.getObjectParameter(entity.id(), "slotCount") * math.min(1000, maxStack)
+
+		if currentLiquidCount > maxCount then
+			currentLiquidCount = maxCount
+		end
 
 		if not animationFrames then animationFrames = world.getObjectParameter(entity.id(), "animationFrames") end
 		imageFrame = math.ceil((currentLiquidCount / maxCount) * animationFrames)


### PR DESCRIPTION
One of the things I found recently was with mods that change the max stack size, your tanks do not get the animation they should unless the person collects a HUGE amount of liquid. Given that BK3K Inventory is a common mod that changes the stack size to 9999, you'd have to collect 10,000 units just to have the animation show the second level.

I've tested this on my own playthrough and liquids levels are more responsive to input. That said, I can understand why such a catch wasn't included as they aren't actually full. But such mods make the tanks look almost perpetually empty when there's more liquid than you know what to do with in the tank.

I made this pull request as a talking point to go with the code. If rejected, I'll understand and thank you for your consideration. I'll just keep a variant for my local use.