### PR TITLE
Universal Monster Drop Compatibility

### DIFF
--- a/treasure/monster.treasurepools.patch
+++ b/treasure/monster.treasurepools.patch
@@ -3,408 +3,1852 @@
   //         Generic Monsters
   // ================================
 
-  {
+  [
+    {
+	"op": "test",
+	"path": "/basicMonsterTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/basicMonsterTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/basicMonsterTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/basicMonsterTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/flyingMonsterTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/flyingMonsterTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/flyingMonsterTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/flyingMonsterTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/robotTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/robotTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/robotTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/robotTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/robothenbabyTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/robothenbabyTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/robothenbabyTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/robothenbabyTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/robothenTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/robothenTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/robothenTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/robothenTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/noMeatMonsterTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/noMeatMonsterTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/noMeatMonsterTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/noMeatMonsterTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/weaklingMonsterTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/weaklingMonsterTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/weaklingMonsterTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/weaklingMonsterTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/smallfishtreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/smallfishtreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/smallfishtreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/smallfishtreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/largefishtreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/largefishtreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/largefishtreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/largefishtreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
   
 
   // ================================
   //       Generated Monsters
   // ================================
 
-  {
+  [
+    {
+    "op": "test",
+	"path": "/generatedGroundMonsterTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/generatedGroundMonsterTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/generatedGroundMonsterTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/generatedGroundMonsterTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/generatedFlyingMonsterTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/generatedFlyingMonsterTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/generatedFlyingMonsterTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/generatedFlyingMonsterTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
 
 
   // ================================
   //        Unique Monsters
   // ================================
 
-  {
+  [
+    {
+    "op": "test",
+	"path": "/adultpoptopTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/adultpoptopTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/adultpoptopTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/adultpoptopTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/anglureTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/anglureTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/anglureTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/anglureTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+	{
+    "op": "test",
+	"path": "/agrobatTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/agrobatTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/agrobatTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/agrobatTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/batongTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/batongTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/batongTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/batongTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/bobfaeTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/bobfaeTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/bobfaeTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/bobfaeTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/bobotTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/bobotTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/bobotTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/bobotTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/bulbopTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/bulbopTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/bulbopTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/bulbopTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/capricoatTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/capricoatTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/capricoatTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/capricoatTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/crabcanoTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/crabcanoTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/crabcanoTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/crabcanoTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/crustoiseTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/crustoiseTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/crustoiseTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/crustoiseTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/crutterTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/crutterTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/crutterTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/crutterTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/fennixTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/fennixTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/fennixTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/fennixTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/gleapTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/gleapTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/gleapTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/gleapTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/hemogoblinTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/hemogoblinTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/hemogoblinTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/hemogoblinTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/hypnareTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/hypnareTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/hypnareTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/hypnareTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/ignomeTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/ignomeTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/ignomeTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/ignomeTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/iguarmorTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/iguarmorTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/iguarmorTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/iguarmorTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/ixolingTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/ixolingTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/ixolingTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/ixolingTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/kluexsentryTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/kluexsentryTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/kluexsentryTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/kluexsentryTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/lilodonTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/lilodonTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/lilodonTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/lilodonTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/lumothTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/lumothTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/lumothTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/lumothTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/mandrafloraTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/mandrafloraTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/mandrafloraTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/mandrafloraTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/miasmopTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/miasmopTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/miasmopTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/miasmopTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/monopusTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/monopusTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/monopusTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/monopusTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/narfinTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/narfinTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/narfinTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/narfinTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/nautileechTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/nautileechTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/nautileechTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/nautileechTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/nutmidgelingTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/nutmidgelingTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/nutmidgelingTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/nutmidgelingTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/oculobTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/oculobTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/oculobTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/oculobTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/ooglerTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/ooglerTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/ooglerTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/ooglerTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/orbideTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/orbideTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/orbideTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/orbideTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/peblitTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/peblitTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/peblitTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/peblitTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/petricubTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/petricubTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/petricubTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/petricubTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/pipkinTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/pipkinTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/pipkinTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/pipkinTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/poptopTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/poptopTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/poptopTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/poptopTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/pteropodTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/pteropodTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/pteropodTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/pteropodTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/pulpinTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/pulpinTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/pulpinTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/pulpinTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/pyromantleTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/pyromantleTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/pyromantleTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/pyromantleTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/quagmuttTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/quagmuttTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/quagmuttTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/quagmuttTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/ringramTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/ringramTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/ringramTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/ringramTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/scandroidTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/scandroidTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/scandroidTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/scandroidTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/scaveranTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/scaveranTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/scaveranTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/scaveranTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/skimbusTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/skimbusTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/skimbusTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
+    "op": "add",
+    "path": "/skimbusTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/smoglinTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/smoglinTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/smoglinTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/smoglinTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/snagglerTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/snagglerTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/snagglerTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/snagglerTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/snauntTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/snauntTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/snauntTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/snauntTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/snuffishTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/snuffishTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/snuffishTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/snuffishTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/spookitTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/spookitTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/spookitTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/spookitTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/sporgusTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/sporgusTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/sporgusTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/sporgusTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/squeemTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/squeemTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/squeemTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/squeemTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/gosmetTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/gosmetTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/gosmetTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/gosmetTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/taroniTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/taroniTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/taroniTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/taroniTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/tinticTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/tinticTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/tinticTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/tinticTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/toumingoTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/toumingoTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/toumingoTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/toumingoTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/trictusTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/trictusTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/trictusTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/trictusTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/triplodTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/triplodTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/triplodTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/triplodTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/voltipTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/voltipTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/voltipTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/voltipTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/wisperTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/wisperTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/wisperTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/wisperTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/yokatTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/yokatTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/yokatTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/yokatTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
 
 
   // ================================
   //   Unique Monster (Vault Pools)
   // ================================
 
-  {
+  [
+    {
+    "op": "test",
+	"path": "/essenceDrop/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/essenceDrop/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/essenceDrop/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/essenceDrop/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
 
 
   // ================================
   //       Old Unique Monsters
   // ================================
 
-  {
+  [
+    {
+    "op": "test",
+	"path": "/bonebirdTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/bonebirdTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/bonebirdTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/bonebirdTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/chickentreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/chickentreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/chickentreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/chickentreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/moontantTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/moontantTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/moontantTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/moontantTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/pogolemTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/pogolemTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/pogolemTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/pogolemTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/smallRobotTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/smallRobotTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  },
-  {
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/smallRobotTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/smallRobotTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/largeRobotTreasure/0/1/fill",
+	"inverse": true
+    },
+	{
     "op": "add",
     "path": "/largeRobotTreasure/0/1/fill",
     "value": [ { "pool" : "enhancedstoragematerial" } ]
-  }
+	}
+  ],
+  [
+    {
+    "op": "test",
+	"path": "/largeRobotTreasure/0/1/fill",
+	"inverse": false
+    },
+	{
+    "op": "add",
+    "path": "/largeRobotTreasure/0/1/fill/-",
+    "value": { "pool" : "enhancedstoragematerial" }
+	}
+  ]
 ]


### PR DESCRIPTION
Changed the patch to monster drop tables to use test patches to see if "fill" exist or not before making the "fill" in the table. If "fill" isn't found, it makes "fill". If "fill" already exists, adds storage matter table to the end of the list.

This solves any incompatibility problems with mods loaded before Enhanced Storage that alter monster drops. (This was once a problem with the lucario once the Lucario Race mod was added to ES's "includes", where ES was overriding Essence of Aura drops, problem is non-existent now since how to obtain EoS was changed, but this mod needed this compatibility change anyways for any other mods that may have problems.)

Since I was told there was a github now, I jumped at the opportunity.